### PR TITLE
Add Docker support and update README

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+target/
+.idea/
+.vscode/
+.gitignore/
+.github/
+.git/
+config/
+LICENSE
+README.md

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ target/
 .vscode/
 config/*.json
 !config/*.example.json
+docker-compose.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM rust:1.79-slim AS builder
+
+RUN apt-get update && apt-get -y install libc6
+COPY . .
+RUN cargo install --path r2d2wm-bot
+
+CMD ["r2d2wm-bot"]

--- a/README.md
+++ b/README.md
@@ -17,8 +17,22 @@ to put it in your configuration file later, so everything can work.
 
 ### 1a. In a docker container
 
-```bash
-# TODO
+An image is available on [Docker Hub](https://hub.docker.com/repository/docker/yanekosaurus/r2d2wm/general).
+Please note that as I'm deploying on a Raspberry Pi 4, it is built for the `linux/arm64` architecture **only**, at least
+for now.
+
+```yaml
+# Example docker-compose.yml:
+services:
+  r2d2wm:
+    image: yanekosaurus/r2d2wm
+    container_name: r2d2wm
+    hostname: r2d2wm
+    restart: unless-stopped
+    volumes:
+      - /home/user/r2d2wm-bot/config:/config
+    environment:
+      R2D2WM_CONFIG_PATH: "/config"
 ```
 
 ### 1b. Build from sources


### PR DESCRIPTION
Added Dockerfile and .dockerignore for Docker support. Instructions for Docker deployment have also been updated in the README. Included a new entry in .gitignore to ignore docker-compose.yml file.